### PR TITLE
fix(utils): Add missing "f" in "f"string

### DIFF
--- a/autoclasstoc/utils.py
+++ b/autoclasstoc/utils.py
@@ -65,7 +65,7 @@ def pick_sections(sections, exclude=None):
         if issubclass(x, Section):
             return x
 
-        raise ConfigError("cannot interpret {x!r} as a section")
+        raise ConfigError(f"cannot interpret {x!r} as a section")
 
     sections = [
             _section_from_anything(x)


### PR DESCRIPTION
While running tests in my fork, I noticed the "f" missing on line 68; I have added the "f" below.

except KeyError:
                 raise ConfigError(f"no sphinxclasstocr section with key {x!r}")